### PR TITLE
[REFACTOR] 카카오 소셜 로그인 로직 분리 (custom hook 사용)

### DIFF
--- a/src/hooks/Auth/UseAuth.ts
+++ b/src/hooks/Auth/UseAuth.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react'
+import axios from 'axios'
+
+const useAuth = () => {
+  const [isLoading, setIsLoading] = useState(true)
+  const [isError, setIsError] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
+  const [accessToken, setAccessToken] = useState(null)
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search)
+    const code = urlParams.get('code')
+
+    if (code) {
+      axios
+        .get('https://api.ideabank.me/oauth', { params: { code } })
+        .then((response) => {
+          const token = response.headers.authorization
+          if (token) {
+            localStorage.setItem('accessToken', token)
+            setAccessToken(token)
+            localStorage.setItem('isLoggedIn', 'true')
+          }
+        })
+        .catch((error) => {
+          setIsError(true)
+          setErrorMessage('Error sending code: ' + error.message)
+        })
+        .finally(() => {
+          setIsLoading(false)
+        })
+    } else {
+      setIsError(true)
+      setErrorMessage('Authorization code missing in URL')
+      setIsLoading(false)
+    }
+  }, [])
+
+  return {
+    isLoading,
+    isError,
+    errorMessage,
+    accessToken,
+  }
+}
+
+export default useAuth

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,7 +17,7 @@ import LikePost from './pages/Mypage/LikePost.tsx'
 import ComingSoon from './pages/Mypage/ComingSoon.tsx'
 import Recipe from './pages/Recipe/Recipe.tsx'
 import RecipeReturn from './pages/Recipe/RecipeReturn.tsx'
-import AuthLoading from './pages/AuthLoading.tsx'
+import AuthLoading from './pages/Splash/AuthLoading.tsx'
 
 const router = createBrowserRouter([
   { path: '/', element: <Main /> },

--- a/src/pages/AuthLoading.tsx
+++ b/src/pages/AuthLoading.tsx
@@ -1,46 +1,57 @@
 import { useEffect } from 'react'
-import axios from 'axios'
 import { useNavigate } from 'react-router-dom'
+import loading from '../assets/splash/loading.gif'
+import ieum from '../assets/splash/ieum.svg'
+import useAuth from '../hooks/Auth/UseAuth'
 
 export default function AuthLoading() {
   const navigate = useNavigate()
-  const back = 'https://api.ideabank.me/'
+  const { isLoading, isError, errorMessage, accessToken } = useAuth()
 
-  // TODO: apiconfig 반영해서 수정하기
   useEffect(() => {
-    // 현재 url에서 인가코드 추출
-    const urlParams = new URLSearchParams(window.location.search)
-    const code = urlParams.get('code')
-    console.log(code)
-
-    // 인가코드 서버로 전송
-    if (code) {
-      axios
-        .get(back + '/oauth', { params: { code } })
-        .then((response) => {
-          console.log('Response from server:', response.headers.authorization)
-
-          // accessToken을 localStorage에 저장
-          const accessToken = response.headers.authorization
-          if (accessToken) {
-            localStorage.setItem('accessToken', accessToken)
-          }
-
-          // 전송 완료시 메인 페이지로 이동
-          navigate('/')
-        })
-        .catch((error) => {
-          console.error('Error sending code:', error)
-        })
+    if (accessToken) {
+      navigate('/') // 액세스 토큰이 있으면 메인 페이지로 이동
     }
-  }, [navigate])
+  }, [accessToken, navigate])
 
-  return (
-    <>
-      <div className="flex flex-col items-center justify-center">
-        <h1>로그인 성공</h1>
-        <h2>Loading...</h2>
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-screen bg-white items-center">
+        <div className="absolute bottom-0 flex flex-col items-center">
+          <div className="flex flex-col items-center gap-2">
+            <p className="font-B00 text-[26px] text-center text-800 leading-140 font-medium">
+              잠시만 기다려주세요
+            </p>
+            <p className="font-M00 text-base text-center text-400 leading-135 font-normal">
+              로그인 중이에요
+            </p>
+          </div>
+          <img
+            src={loading}
+            alt="loading"
+            className="w-[134px] h-[134px] mt-[45.12px] mb-[14px]"
+          />
+          <img src={ieum} alt="이음" className="mb-[-31.5px] z-10" />
+          <div className="w-[390px] h-[115px] bg-Main2"></div>
+        </div>
       </div>
-    </>
-  )
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col h-screen bg-white items-center">
+        <div className="absolute bottom-0 flex flex-col items-center">
+          <p className="font-B00 text-[26px] text-center text-800 leading-140 font-medium">
+            로그인 오류
+          </p>
+          <p className="font-M00 text-base text-center text-400 leading-135 font-normal">
+            {errorMessage}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return null
 }

--- a/src/pages/Splash/AuthLoading.tsx
+++ b/src/pages/Splash/AuthLoading.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import loading from '../assets/splash/loading.gif'
-import ieum from '../assets/splash/ieum.svg'
-import useAuth from '../hooks/Auth/UseAuth'
+import loading from '../../assets/splash/loading.gif'
+import ieum from '../../assets/splash/ieum.svg'
+import useAuth from '../../hooks/Auth/UseAuth'
 
 export default function AuthLoading() {
   const navigate = useNavigate()


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 카카오 소셜 로그인 로직을 custom hook을 이용하여 분리하였습니다. `UseAuth.ts`
> 카카오 소셜 로그인을 통해 서버로부터 받아오는 AT를 로컬 스토리지에 저장합니다.

### 스크린샷 

> ![무제](https://github.com/user-attachments/assets/dc62fa6b-24d5-437a-9d4e-dd8ca5904b86)

## 💬리뷰 요구사항

> main 브랜치에 머지 후 배포 환경에서도 잘 동작하는지 테스트 해보겠습니다!
