### PR TITLE
[FEAT] 소셜 로그인 파라미터 추가

### DIFF
--- a/src/hooks/Auth/UseAuth.ts
+++ b/src/hooks/Auth/UseAuth.ts
@@ -1,19 +1,28 @@
 import { useState, useEffect } from 'react'
 import axios from 'axios'
+import { useLocation } from 'react-router-dom'
 
 const useAuth = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
-  const [accessToken, setAccessToken] = useState(null)
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+  const location = useLocation()
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search)
     const code = urlParams.get('code')
+    const redirectUrl = window.location.origin + location.pathname // 현재 주소
+    alert(redirectUrl)
 
     if (code) {
       axios
-        .get('https://api.ideabank.me/oauth', { params: { code } })
+        .get('https://api.ideabank.me/oauth', {
+          params: {
+            code,
+            redirect_url: redirectUrl, // 현재 주소를 redirect_url로 설정
+          },
+        })
         .then((response) => {
           const token = response.headers.authorization
           if (token) {
@@ -34,7 +43,7 @@ const useAuth = () => {
       setErrorMessage('Authorization code missing in URL')
       setIsLoading(false)
     }
-  }, [])
+  }, [location])
 
   return {
     isLoading,


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> 서버에서 동적으로 리다이렉트 주소를 처리하기 위해 인가 코드와 redirect url을 파라미터로 전송합니다. 
`ex) https://api.ideabank.me/oauth?code=uZP1KH&redirect_url=http:%2F%2Flocalhost:5173%2Fauth`