### PR TITLE
[REFACTOR] 카카오 소셜 로그인 연동

### DIFF
--- a/src/hooks/Auth/UseAuth.ts
+++ b/src/hooks/Auth/UseAuth.ts
@@ -13,7 +13,7 @@ const useAuth = () => {
     const urlParams = new URLSearchParams(window.location.search)
     const code = urlParams.get('code')
     const redirectUrl = window.location.origin + location.pathname // 현재 주소
-    alert(redirectUrl)
+    console.log(redirectUrl)
 
     if (code) {
       axios

--- a/src/hooks/Auth/UseAuth.ts
+++ b/src/hooks/Auth/UseAuth.ts
@@ -13,25 +13,14 @@ const useAuth = () => {
     const urlParams = new URLSearchParams(window.location.search)
     const code = urlParams.get('code')
     const redirectUrl = window.location.origin + location.pathname // 현재 주소
-
-    // 디버깅용 콘솔 로그
-    console.log('Redirect URL:', redirectUrl)
-    console.log('Location:', location)
-    console.log('Origin:', window.location.origin)
-    console.log('Pathname:', location.pathname)
+    alert(redirectUrl)
 
     if (code) {
       axios
         .get('https://api.ideabank.me/oauth', {
           params: {
             code,
-            redirect_url: redirectUrl, // 현재 주소를 redirect_url로 설정
-          },
-          paramsSerializer: (params) => {
-            // 파라미터 직접 직렬화
-            return Object.entries(params)
-              .map(([key, value]) => `${key}=${value}`)
-              .join('&')
+            redirect_uri: redirectUrl, // 현재 주소를 redirect_url로 설정
           },
         })
         .then((response) => {
@@ -45,7 +34,6 @@ const useAuth = () => {
         .catch((error) => {
           setIsError(true)
           setErrorMessage('Error sending code: ' + error.message)
-          console.error('Full error:', error.response)
         })
         .finally(() => {
           setIsLoading(false)

--- a/src/hooks/Auth/UseAuth.ts
+++ b/src/hooks/Auth/UseAuth.ts
@@ -12,10 +12,13 @@ const useAuth = () => {
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search)
     const code = urlParams.get('code')
-    const redirectUrl = encodeURIComponent(
-      window.location.origin + location.pathname
-    ) // 현재 주소
-    alert(redirectUrl)
+    const redirectUrl = window.location.origin + location.pathname // 현재 주소
+
+    // 디버깅용 콘솔 로그
+    console.log('Redirect URL:', redirectUrl)
+    console.log('Location:', location)
+    console.log('Origin:', window.location.origin)
+    console.log('Pathname:', location.pathname)
 
     if (code) {
       axios
@@ -23,6 +26,12 @@ const useAuth = () => {
           params: {
             code,
             redirect_url: redirectUrl, // 현재 주소를 redirect_url로 설정
+          },
+          paramsSerializer: (params) => {
+            // 파라미터 직접 직렬화
+            return Object.entries(params)
+              .map(([key, value]) => `${key}=${value}`)
+              .join('&')
           },
         })
         .then((response) => {
@@ -36,6 +45,7 @@ const useAuth = () => {
         .catch((error) => {
           setIsError(true)
           setErrorMessage('Error sending code: ' + error.message)
+          console.error('Full error:', error.response)
         })
         .finally(() => {
           setIsLoading(false)

--- a/src/hooks/Auth/UseAuth.ts
+++ b/src/hooks/Auth/UseAuth.ts
@@ -12,7 +12,9 @@ const useAuth = () => {
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search)
     const code = urlParams.get('code')
-    const redirectUrl = window.location.origin + location.pathname // 현재 주소
+    const redirectUrl = encodeURIComponent(
+      window.location.origin + location.pathname
+    ) // 현재 주소
     alert(redirectUrl)
 
     if (code) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #24 

## 📝작업 내용

> - 카카오 소셜 로그인시, 서버로 인가 코드와 rediret_uri를 파라미터로 전송합니다.
> - 현재 Vercel 환경 변수에 기본으로 설정된 Redirect URI는 main 브랜치에 해당하는 URI입니다.
> 만약 각자의 브랜치나 dev 브랜치에서 배포된 사이트에서 소셜 로그인 기능을 테스트하고 싶다면,
> `테스트 하고 싶은 사이트/auth`로 Redirect URI 환경 변수를 변경하셔야 로그인 기능이 정상적으로 작동합니다.

### 스크린샷

## 💬리뷰 요구사항

> 혹시 이해 안 가시는 부분 있음 편하게 물어봐 주세용
