### PR TITLE
[FEAT] 게시글 없을 시 컴포넌트 구현

### DIFF
--- a/src/components/Community/NoContents.tsx
+++ b/src/components/Community/NoContents.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import ieum from '../../assets/splash/preparing_ieum.svg'
+
+const NoContents: React.FC = () => {
+  return (
+    <div className="flex justify-center items-center bg-white">
+      <div className="flex flex-col items-center justify-center gap-[61px] mt-[148px]">
+        <p className="font-B00 text-[26px] text-center text-800 leading-140 font-medium">
+          앗 작성된 글이 없어요!
+        </p>
+        <img src={ieum} alt="이음_프로필" />
+      </div>
+    </div>
+  )
+}
+
+export default NoContents

--- a/src/components/Community/NoContents.tsx
+++ b/src/components/Community/NoContents.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import ieum from '../../assets/splash/preparing_ieum.svg'
 
-const NoContents: React.FC = () => {
+const NoContents: React.FC<{ store?: boolean }> = ({ store }) => {
   return (
     <div className="flex justify-center items-center bg-white">
       <div className="flex flex-col items-center justify-center gap-[61px] mt-[148px]">
-        <p className="font-B00 text-[26px] text-center text-800 leading-140 font-medium">
-          앗 작성된 글이 없어요!
+        <p className="font-B00 text-[26px] text-center text-800 leading-140 font-medium whitespace-pre-wrap">
+          {store
+            ? '앗 1km 내에 \n존재하는 가맹점이 없어요!'
+            : '앗 작성된 글이 없어요!'}
         </p>
         <img src={ieum} alt="이음_프로필" />
       </div>

--- a/src/hooks/MyPage/useMyPage.ts
+++ b/src/hooks/MyPage/useMyPage.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import defaultAxios from '../../api/defaultAxios'
-import profileResponse from '../../types/MyPage/ProfileResponse'
 import { getCategoryContentResponse } from '../../types/Community/PostResponse'
+import profile from '../../types/MyPage/ProfileResponse'
 
 const useMypage = () => {
   // 사용자 정보 response
-  const [profileInfo, setProfileInfo] = useState<profileResponse | null>(null)
+  const [profileInfo, setProfileInfo] = useState<profile | null>(null)
   // 특정 게시글 조회 response
   const [postInfo, setPostInfo] = useState<getCategoryContentResponse | null>(
     null
@@ -20,7 +20,7 @@ const useMypage = () => {
       setIsLoading(true)
       const response = await defaultAxios.get(`/user/info`)
       console.log(response.data)
-      setProfileInfo(response.data)
+      setProfileInfo(response.data.data)
     } catch (error) {
       setIsError(true)
       console.error(error)

--- a/src/pages/Community/Community.tsx
+++ b/src/pages/Community/Community.tsx
@@ -7,6 +7,7 @@ import WriteButton from '../../components/Community/WriteButton'
 import useCommunity from '../../hooks/Community/useCommmunity'
 import { categoryArr } from '../../utils/category'
 import LoadingSplash from '../Splash/LoadingSplash'
+import NoContents from '../../components/Community/NoContents'
 
 const Community: React.FC = () => {
   const { fetchGetCategoryContents, categoryCommentInfo, isLoading } =
@@ -34,22 +35,26 @@ const Community: React.FC = () => {
           <ScrollCategoryBar onCategoryChange={handleCategoryChange} />
           {/* 카테고리 변경 핸들러 전달 */}
           <div className="flex flex-col gap-[10px]">
-            {categoryCommentInfo?.data.map((content, index) => (
-              <Contents
-                key={content.post_id}
-                nickname={content.author}
-                title={content.title}
-                content={content.content}
-                updateHour={content.created_at}
-                imgUrl={content.author_profile_url}
-                postId={content.post_id}
-                category={content.post_category}
-                likes={content.like_user.length}
-                comments={content.comment_count}
-                isLabel
-                isLastComment={index === categoryCommentInfo?.data.length - 1}
-              />
-            ))}
+            {categoryCommentInfo?.data.length === 0 ? (
+              <NoContents />
+            ) : (
+              categoryCommentInfo?.data.map((content, index) => (
+                <Contents
+                  key={content.post_id}
+                  nickname={content.author}
+                  title={content.title}
+                  content={content.content}
+                  updateHour={content.created_at}
+                  imgUrl={content.author_profile_url}
+                  postId={content.post_id}
+                  category={content.post_category}
+                  likes={content.like_user.length}
+                  comments={content.comment_count}
+                  isLabel
+                  isLastComment={index === categoryCommentInfo?.data.length - 1}
+                />
+              ))
+            )}
           </div>
           <div className="fixed bottom-[108px] z-50 self-end">
             <WriteButton />

--- a/src/pages/Mypage/CommentPost.tsx
+++ b/src/pages/Mypage/CommentPost.tsx
@@ -3,6 +3,7 @@ import Contents from '../../components/Community/Contents'
 import MyPageHeader from '../../components/MyPage/MyPageHeader'
 import { useLocation } from 'react-router-dom'
 import useMypage from '../../hooks/MyPage/useMyPage'
+import NoContents from '../../components/Community/NoContents'
 
 const CommentPost: React.FC = () => {
   const { postInfo, fetchGetSpecPosts } = useMypage()
@@ -17,22 +18,26 @@ const CommentPost: React.FC = () => {
       <div className="max-w-[390px]">
         <MyPageHeader title="댓글 단 글" />
         <div className="p-4 flex flex-col gap-4 border-t border-200">
-          {postInfo?.data.map((post) => (
-            <Contents
-              key={post.post_id}
-              nickname={post.author}
-              title={post.title}
-              content={post.content}
-              imgUrl={post.author_profile_url}
-              category={post.post_category}
-              updateHour={post.created_at}
-              postId={post.post_id}
-              isLabel
-              isLastComment={false}
-              likes={post.likes}
-              comments={post.comment_count}
-            />
-          ))}
+          {postInfo?.data.length === 0 ? (
+            <NoContents />
+          ) : (
+            postInfo?.data.map((post) => (
+              <Contents
+                key={post.post_id}
+                nickname={post.author}
+                title={post.title}
+                content={post.content}
+                imgUrl={post.author_profile_url}
+                category={post.post_category}
+                updateHour={post.created_at}
+                postId={post.post_id}
+                isLabel
+                isLastComment={false}
+                likes={post.likes}
+                comments={post.comment_count}
+              />
+            ))
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/Mypage/LikePost.tsx
+++ b/src/pages/Mypage/LikePost.tsx
@@ -3,6 +3,7 @@ import Contents from '../../components/Community/Contents'
 import MyPageHeader from '../../components/MyPage/MyPageHeader'
 import { useLocation } from 'react-router-dom'
 import useMypage from '../../hooks/MyPage/useMyPage'
+import NoContents from '../../components/Community/NoContents'
 
 const LikePost: React.FC = () => {
   const { postInfo, fetchGetSpecPosts } = useMypage()
@@ -17,22 +18,26 @@ const LikePost: React.FC = () => {
       <div className="max-w-[390px]">
         <MyPageHeader title="좋아요 누른 글" />
         <div className="p-4 flex flex-col gap-4 border-t border-200">
-          {postInfo?.data.map((post) => (
-            <Contents
-              key={post.post_id}
-              nickname={post.author}
-              title={post.title}
-              content={post.content}
-              imgUrl={post.author_profile_url}
-              category={post.post_category}
-              updateHour={post.created_at}
-              postId={post.post_id}
-              isLabel
-              isLastComment={false}
-              likes={post.likes}
-              comments={post.comment_count}
-            />
-          ))}
+          {postInfo?.data.length === 0 ? (
+            <NoContents />
+          ) : (
+            postInfo?.data.map((post) => (
+              <Contents
+                key={post.post_id}
+                nickname={post.author}
+                title={post.title}
+                content={post.content}
+                imgUrl={post.author_profile_url}
+                category={post.post_category}
+                updateHour={post.created_at}
+                postId={post.post_id}
+                isLabel
+                isLastComment={false}
+                likes={post.likes}
+                comments={post.comment_count}
+              />
+            ))
+          )}
         </div>
       </div>
     </div>

--- a/src/pages/Mypage/MyPage.tsx
+++ b/src/pages/Mypage/MyPage.tsx
@@ -66,11 +66,11 @@ function MyPage() {
         </div>
         <div className="border-t border-200 bg-Main w-full h-[212px] flex flex-col items-center justify-center">
           <img
-            src={profileInfo?.data.profileUrl}
+            src={profileInfo?.profileUrl}
             alt="프로필 사진"
             className="w-[96px] h-[96px] rounded-full mb-[16px]"
           />
-          <p className="font-SB00 mb-3">{profileInfo?.data.name}</p>
+          <p className="font-SB00 mb-3">{profileInfo?.name}</p>
         </div>
         <p className="w-full px-4 pt-6 pb-2 font-SB00">활동내역</p>
         <div className="p-3 grid grid-cols-3 gap-3 h-36">

--- a/src/pages/Mypage/WrittenPost.tsx
+++ b/src/pages/Mypage/WrittenPost.tsx
@@ -3,6 +3,7 @@ import Contents from '../../components/Community/Contents'
 import MyPageHeader from '../../components/MyPage/MyPageHeader'
 import useMypage from '../../hooks/MyPage/useMyPage'
 import { useLocation } from 'react-router-dom'
+import NoContents from '../../components/Community/NoContents'
 
 const WrittenPost: React.FC = () => {
   const { postInfo, fetchGetSpecPosts } = useMypage()
@@ -17,22 +18,26 @@ const WrittenPost: React.FC = () => {
       <div className="max-w-[390px]">
         <MyPageHeader title="작성한 글" />
         <div className="p-4 flex flex-col gap-4 border-t border-200">
-          {postInfo?.data.map((post) => (
-            <Contents
-              key={post.post_id}
-              nickname={post.author}
-              title={post.title}
-              content={post.content}
-              imgUrl={post.author_profile_url}
-              category={post.post_category}
-              updateHour={post.created_at}
-              postId={post.post_id}
-              isLabel
-              isLastComment={false}
-              likes={post.likes}
-              comments={post.comment_count}
-            />
-          ))}
+          {postInfo?.data.length === 0 ? (
+            <NoContents />
+          ) : (
+            postInfo?.data.map((post) => (
+              <Contents
+                key={post.post_id}
+                nickname={post.author}
+                title={post.title}
+                content={post.content}
+                imgUrl={post.author_profile_url}
+                category={post.post_category}
+                updateHour={post.created_at}
+                postId={post.post_id}
+                isLabel
+                isLastComment={false}
+                likes={post.likes}
+                comments={post.comment_count}
+              />
+            ))
+          )}
         </div>
       </div>
     </div>

--- a/src/types/MyPage/ProfileResponse.ts
+++ b/src/types/MyPage/ProfileResponse.ts
@@ -1,10 +1,5 @@
-interface profile {
+export default interface profile {
   email: string
   name: string
   profileUrl: string
-}
-
-export default interface profileResponse {
-  code: number
-  data: profile
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 게시글 없을 시 컴포넌트 구현
- 커뮤니티, 마이페이지에 적용
- 만약 가맹점 검색 결과가 없을 경우, NoContents 컴포넌트에 속성 store만 적어주시면 해당 문구로 변경됩니다!

### 스크린샷 (선택)
<img width="415" alt="스크린샷 2024-11-22 오후 11 55 09" src="https://github.com/user-attachments/assets/49a53f21-4df4-4b19-b36a-92b00dfd3bbd">
<img width="405" alt="스크린샷 2024-11-22 오후 11 55 32" src="https://github.com/user-attachments/assets/07e364a3-a986-4136-b2e1-377908bb9ff5">

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
