### PR TITLE
[FEAT] 변경된 주소 설정 api 재연동 및 주소 검색 기능 추가

### DIFF
--- a/src/assets/address/Close.svg
+++ b/src/assets/address/Close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.75 5.33337L5 19.0834" stroke="#CBCDD2" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M5 5.33337L18.75 19.0834" stroke="#CBCDD2" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/Community/NoContents.tsx
+++ b/src/components/Community/NoContents.tsx
@@ -6,6 +6,7 @@ const subjects = {
   commented: '댓글을 단 게시글이\n 없어요!',
   liked: '좋아요 누른 글이\n 없어요!',
   store: '앗 1km 내에 \n존재하는 가맹점이 없어요!',
+  address: '앗 설정된 주소가 없어요!',
 }
 
 const NoContents: React.FC<{ subjectKey?: keyof typeof subjects }> = ({

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -87,7 +87,10 @@ function Header() {
             <img src={logoText} alt="logoText" className="w-[37.33px] h-7" />
           </div>
           <div className="flex flex-row gap-[10px] items-center justify-center">
-            <div className="flex gap-2 items-center">
+            <div
+              onClick={() => navigation('/address')}
+              className="flex gap-2 items-center"
+            >
               <div className="font-SB00 text-[16px] text-ellipsis line-clamp-1">
                 {selectedAddress || '주소 설정하기'}
               </div>
@@ -95,7 +98,6 @@ function Header() {
                 src={arrow}
                 alt="Arrow"
                 className="w-4 h-[6px] cursor-pointer"
-                onClick={() => navigation('/address')}
               />
             </div>
             <img

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -62,14 +62,16 @@ function Header() {
   }, [])
 
   useEffect(() => {
-    fetchAddressList()
-    if (addresses.length > 0) {
-      const firstAddress = addresses[0]
-      if (!getSelectedAddress()) {
-        selectAddress(firstAddress.id) // 첫 번째 주소를 선택
+    const initializeAddresses = async () => {
+      await fetchAddressList() // 주소 리스트 가져오기
+      const firstAddress = addresses[0] // 첫 번째 주소 가져오기
+      if (!getSelectedAddress() && firstAddress) {
+        selectAddress(firstAddress.id) // 첫 번째 주소 선택
       }
     }
-  }, [addresses, selectAddress, getSelectedAddress])
+
+    initializeAddresses()
+  }, []) // 의존성 배열을 비워서 처음에 한 번만 실행
 
   const selectedAddress = getSelectedAddress()
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,10 +9,12 @@ import useAddressStore from '../store/useAddressStore'
 import { useSearch } from '../hooks/UseSearch'
 import useMapStore from '../store/useMapStore'
 import useMypage from '../hooks/MyPage/useMyPage'
+import { useAddress } from '../hooks/Main/UseAddress'
 
 function Header() {
   const navigation = useNavigate()
-  const { getSelectedAddress } = useAddressStore()
+  const { addresses, selectAddress, getSelectedAddress } = useAddressStore()
+  const { fetchAddressList } = useAddress()
   const { setSelectedPlace } = useMapStore()
   const { profileInfo, fetchGetProfile } = useMypage()
 
@@ -59,6 +61,18 @@ function Header() {
     fetchGetProfile()
   }, [])
 
+  useEffect(() => {
+    fetchAddressList()
+    if (addresses.length > 0) {
+      const firstAddress = addresses[0]
+      if (!getSelectedAddress()) {
+        selectAddress(firstAddress.id) // 첫 번째 주소를 선택
+      }
+    }
+  }, [addresses, selectAddress, getSelectedAddress])
+
+  const selectedAddress = getSelectedAddress()
+
   return (
     <>
       <header className="mt-7 ml-[17px] mr-[19px] w-[390px]">
@@ -73,7 +87,7 @@ function Header() {
           <div className="flex flex-row gap-[10px] items-center justify-center">
             <div className="flex gap-2 items-center">
               <div className="font-SB00 text-[16px] text-ellipsis line-clamp-1">
-                {getSelectedAddress() || '주소 설정하기'}
+                {selectedAddress || '주소 설정하기'}
               </div>
               <img
                 src={arrow}

--- a/src/components/Main/AddressCard.tsx
+++ b/src/components/Main/AddressCard.tsx
@@ -1,7 +1,10 @@
 import useAddressStore from '../../store/useAddressStore'
 import LocationIcon from '../../assets/address/Location.svg?react'
+import deleteIcon from '../../assets/address/Close.svg'
+import { useAddress } from '../../hooks/Main/UseAddress'
 
 interface AddressCardProps {
+  id: number
   index: number
   selected?: boolean
   address: string
@@ -9,39 +12,64 @@ interface AddressCardProps {
 }
 
 export default function AddressCard({
-  index,
+  id, // id 받기
   selected,
   address,
   isLastAddress,
 }: AddressCardProps) {
   const { selectAddress } = useAddressStore()
+  const { deleteLocation, updatePriority } = useAddress()
+
+  const handleClick = async () => {
+    selectAddress(id) // 주소 선택
+
+    try {
+      await updatePriority(id) // 우선순위 업데이트
+    } catch (error) {
+      console.error('우선순위 업데이트 중 오류 발생:', error)
+    }
+  }
 
   return (
     <div
-      onClick={() => selectAddress(index)}
-      className={`py-5 w-full flex flex-row gap-[10px] ${
+      onClick={handleClick} // 기존대로 index 사용
+      className={`px-[1px] py-5 w-full flex justify-between ${
         isLastAddress ? '' : 'border-b'
       } border-200 items-center cursor-pointer`}
     >
-      <LocationIcon
-        style={{
-          width: selected ? '24px' : '20px',
-          height: selected ? '24px' : '20px',
-          fill: selected ? '#F4635E' : '#CBCDD2',
-        }}
-      />
-      <div
-        className={`font-SB00 text-[14px] ${
-          selected ? 'text-800' : 'text-400'
-        }`}
-      >
-        {address}
-      </div>
-      {selected && (
-        <div className="p-[6px] bg-100 text-400 text-[10px] rounded-[20px] border border-200">
-          현재 설정된 주소
+      <div className="flex flex-row gap-[10px] items-center">
+        <LocationIcon
+          style={{
+            width: selected ? '24px' : '20px',
+            height: selected ? '24px' : '20px',
+            fill: selected ? '#F4635E' : '#CBCDD2',
+          }}
+        />
+        <div
+          className={`font-SB00 text-[14px] ${
+            selected
+              ? 'text-800 max-w-[159px] whitespace-normal break-words overflow-hidden text-ellipsis line-clamp-2 '
+              : 'text-400'
+          }`}
+        >
+          {address}
         </div>
-      )}
+        {selected && (
+          <div className="p-[6px] bg-100 text-400 text-[10px] rounded-[20px] border border-200">
+            현재 설정된 주소
+          </div>
+        )}
+      </div>
+
+      <img
+        src={deleteIcon}
+        alt="delete address"
+        onClick={(e) => {
+          e.stopPropagation() // 클릭 이벤트 전파 방지
+          deleteLocation(id) // id 사용
+        }}
+        className="w-5 h-5"
+      />
     </div>
   )
 }

--- a/src/hooks/Main/UseAddress.ts
+++ b/src/hooks/Main/UseAddress.ts
@@ -169,33 +169,49 @@ export const useAddress = () => {
       return
     }
 
-    setIsLoading(true)
-    navigator.geolocation.getCurrentPosition(
-      async (position) => {
-        const latitude = position.coords.latitude
-        const longitude = position.coords.longitude
+    setIsLoading(true) // 로딩 상태를 먼저 true로 설정
 
-        const roadAddressName = await getRoadAddressName(latitude, longitude)
+    try {
+      await new Promise<void>((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(
+          async (position) => {
+            const latitude = position.coords.latitude
+            const longitude = position.coords.longitude
 
-        // 주소 기반 중복 체크
-        const isDuplicate = addresses.some(
-          (item) => item.address === roadAddressName
+            const roadAddressName = await getRoadAddressName(
+              latitude,
+              longitude
+            )
+
+            // 주소 기반 중복 체크
+            const isDuplicate = addresses.some(
+              (item) => item.address === roadAddressName
+            )
+
+            if (isDuplicate) {
+              alert('현재 위치와 동일한 주소가 이미 저장되어 있어요!')
+              resolve()
+              return
+            }
+
+            await addNewLocation(latitude, longitude)
+            resolve()
+          },
+          (error) => {
+            console.error(error.message)
+            setErrorMessage(
+              '위치를 가져오는 데 실패했습니다. 권한을 확인하세요.'
+            )
+            reject(error)
+          },
+          { enableHighAccuracy: true }
         )
-
-        if (isDuplicate) {
-          alert('현재 위치와 동일한 주소가 이미 저장되어 있어요!')
-          return
-        }
-
-        await addNewLocation(latitude, longitude)
-      },
-      (error) => {
-        console.error(error.message)
-        setErrorMessage('위치를 가져오는 데 실패했습니다. 권한을 확인하세요.')
-      },
-      { enableHighAccuracy: true }
-    )
-    setIsLoading(false)
+      })
+    } catch (error) {
+      // 에러 처리
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return {

--- a/src/hooks/Main/UseAddress.ts
+++ b/src/hooks/Main/UseAddress.ts
@@ -1,8 +1,11 @@
 import { useState, useEffect } from 'react'
-import { addressRequest } from '../../types/Main/AddressRequest'
-import { addressResponse } from '../../types/Main/AddressResponse'
+import {
+  addressResponse,
+  addressListResponse,
+} from '../../types/Main/AddressResponse'
 import defaultAxios from '../../api/defaultAxios'
 import useAddressStore from '../../store/useAddressStore'
+import { Address } from '../../store/useAddressStore'
 
 declare global {
   interface Window {
@@ -11,65 +14,182 @@ declare global {
 }
 
 export const useAddress = () => {
-  const { addresses, addAddress } = useAddressStore()
+  const { addresses, addAddress, setAddresses } = useAddressStore()
 
   const [isLoading, setIsLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
-  const [userLocation, setUserLocation] = useState<addressResponse | undefined>(
-    undefined
-  )
+  const [addressList, setAddressList] = useState<
+    addressListResponse | undefined
+  >(undefined)
   const [address, setAddress] = useState('')
 
   useEffect(() => {
-    const fetchUserLocation = async () => {
-      try {
-        const response = await defaultAxios.get('/user/location')
-        const { latitude, longitude }: addressResponse = response.data.data
+    fetchAddressList()
+  }, [setAddresses])
 
-        setUserLocation({ latitude, longitude })
+  // 주소 리스트 받아오기
+  const fetchAddressList = async () => {
+    try {
+      setIsLoading(true)
+      const response = await defaultAxios.get<addressListResponse>(
+        '/user/location'
+      )
+      console.log(response.data)
+      setAddressList(response.data)
 
-        // 좌표 기반으로 중복 체크
-        const isDuplicate = addresses.some(
-          (item) =>
-            item.coordinates?.latitude === latitude &&
-            item.coordinates?.longitude === longitude
-        )
+      const transformedAddresses = await mapAddressResponseToAddress(
+        response.data
+      )
 
-        if (!isDuplicate) {
-          const geocoder = new window.kakao.maps.services.Geocoder()
+      // 기존 선택된 주소의 ID 찾기
+      const currentSelectedAddressId = addresses.find(
+        (addr) => addr.selected
+      )?.id
+
+      // 새로운 주소 목록에서 기존 선택 상태 복원
+      const addressesWithSelection = transformedAddresses.map((addr) => ({
+        ...addr,
+        selected: addr.id === currentSelectedAddressId,
+      }))
+
+      useAddressStore.getState().setAddresses(addressesWithSelection)
+    } catch (error) {
+      setErrorMessage('주소 리스트를 가져오는 데 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const mapAddressResponseToAddress = async (
+    response: addressListResponse
+  ): Promise<Address[]> => {
+    const geocoder = new window.kakao.maps.services.Geocoder()
+
+    const addresses = await Promise.all(
+      response.data.map(async (item) => {
+        // 이미 roadAddressName이 존재하면 변환 작업 생략
+        if (item.roadAddressName) {
+          return {
+            id: item.id,
+            address: item.roadAddressName,
+            coordinates: {
+              latitude: item.latitude,
+              longitude: item.longitude,
+            },
+            priority: item.priority,
+            selected: false,
+          }
+        }
+
+        // 도로명 주소 변환 작업
+        let roadAddressName = ''
+        await new Promise<void>((resolve) => {
           geocoder.coord2Address(
-            longitude,
-            latitude,
+            item.longitude,
+            item.latitude,
             (result: any, status: any) => {
               if (status === window.kakao.maps.services.Status.OK) {
-                const roadAddress = result[0].road_address
-                const jibunAddress = result[0].address
-
-                if (roadAddress) {
-                  setAddress(roadAddress.address_name)
-                  // 좌표 정보와 함께 주소 저장
-                  addAddress(roadAddress.address_name, true, {
-                    latitude,
-                    longitude,
-                  })
-                } else if (jibunAddress) {
-                  setAddress(jibunAddress.address_name)
-                  addAddress(jibunAddress.address_name, true, {
-                    latitude,
-                    longitude,
-                  })
-                }
+                roadAddressName =
+                  result[0]?.road_address?.address_name ||
+                  result[0]?.address?.address_name ||
+                  ''
               }
+              resolve()
             }
           )
-        }
-      } catch (error) {
-        setErrorMessage('위치 정보를 가져오는 데 실패했습니다.')
-      }
-    }
+        })
 
-    fetchUserLocation()
-  }, [addresses, addAddress]) // address 의존성 제거
+        return {
+          id: item.id,
+          address: roadAddressName || `Address-${item.id}`,
+          coordinates: {
+            latitude: item.latitude,
+            longitude: item.longitude,
+          },
+          priority: item.priority,
+          selected: false,
+        }
+      })
+    )
+
+    return addresses
+  }
+
+  // 새로운 주소 추가하기
+  const addNewLocation = async (latitude: number, longitude: number) => {
+    try {
+      setIsLoading(true)
+      await defaultAxios.post('/user/location', { latitude, longitude })
+      const geocoder = new window.kakao.maps.services.Geocoder()
+
+      let roadAddressName = ''
+      await new Promise<void>((resolve) => {
+        geocoder.coord2Address(
+          longitude,
+          latitude,
+          (result: any, status: any) => {
+            if (status === window.kakao.maps.services.Status.OK) {
+              roadAddressName =
+                result[0]?.road_address?.address_name ||
+                result[0]?.address?.address_name ||
+                ''
+            }
+            resolve()
+          }
+        )
+      })
+
+      const maxId =
+        addresses.length > 0 ? Math.max(...addresses.map((a) => a.id)) : 0
+      const newAddress = {
+        id: maxId + 1,
+        address: roadAddressName || `Address-${maxId + 1}`,
+        coordinates: { latitude, longitude },
+        priority: addresses.length,
+        selected: false,
+      }
+
+      useAddressStore
+        .getState()
+        .addAddress(
+          newAddress.id,
+          newAddress.address,
+          false,
+          newAddress.coordinates,
+          newAddress.priority
+        )
+    } catch (error) {
+      setErrorMessage('새로운 위치를 추가하는 데 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // 선택된 주소 우선순위 높이기
+  const updatePriority = async (id: number) => {
+    try {
+      setIsLoading(true)
+      await defaultAxios.patch(`/user/location?id=${id}`)
+      await fetchAddressList()
+    } catch (error) {
+      setErrorMessage('우선순위를 수정하는 데 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  // 주소 삭제하기
+  const deleteLocation = async (id: number) => {
+    try {
+      setIsLoading(true)
+      await defaultAxios.delete(`/user/location?id=${id}`)
+      await fetchAddressList()
+    } catch (error) {
+      setErrorMessage('위치를 삭제하는 데 실패했습니다.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
   const handleSetCurrentLocation = async () => {
     if (navigator.geolocation) {
@@ -80,61 +200,82 @@ export const useAddress = () => {
             const latitude = position.coords.latitude
             const longitude = position.coords.longitude
 
-            // 좌표 기반으로 중복 체크
+            // 중복 좌표 체크
             const isDuplicate = addresses.some(
               (item) =>
                 item.coordinates?.latitude === latitude &&
                 item.coordinates?.longitude === longitude
             )
-
             if (isDuplicate) {
               alert('현재 위치가 이미 저장되어 있어요!')
               setIsLoading(false)
-              return // 중복된 좌표면 여기서 종료
+              return
             }
 
-            // 중복이 아닐 경우에만 계속 진행
-            const requestData: addressRequest = { latitude, longitude }
-            await defaultAxios.patch('/user/location', requestData)
+            await addNewLocation(latitude, longitude)
 
-            // 카카오 지도 API로 주소 가져오기
             const geocoder = new window.kakao.maps.services.Geocoder()
             geocoder.coord2Address(
               longitude,
               latitude,
               (result: any, status: any) => {
                 if (status === window.kakao.maps.services.Status.OK) {
-                  const roadAddress = result[0].road_address
-                  const jibunAddress = result[0].address
+                  const roadAddress = result[0]?.road_address
+                  const jibunAddress = result[0]?.address
+                  const selectedAddress = roadAddress || jibunAddress
 
-                  if (roadAddress) {
-                    setAddress(roadAddress.address_name)
-                    addAddress(roadAddress.address_name, true, {
+                  if (selectedAddress) {
+                    const maxId = addressList
+                      ? Math.max(...addressList.data.map((item) => item.id), 0)
+                      : 0
+                    const maxPriority = addressList
+                      ? Math.max(
+                          ...addressList.data.map((item) => item.priority),
+                          0
+                        )
+                      : 0
+
+                    const id = maxId + 1 // 가장 큰 id에 +1
+                    const priority = maxPriority + 1 // 가장 큰 priority에 +1
+
+                    // 새 객체 생성
+                    const newAddress: addressResponse = {
+                      id,
                       latitude,
                       longitude,
-                    })
-                  } else if (jibunAddress) {
-                    setAddress(jibunAddress.address_name)
-                    addAddress(jibunAddress.address_name, true, {
-                      latitude,
-                      longitude,
-                    })
+                      priority,
+                      roadAddressName: selectedAddress.address_name, // 도로명 또는 지번 주소
+                    }
+
+                    // addressList에 새 데이터 추가
+                    const updatedAddressList: addressListResponse = {
+                      code: addressList?.code || 200, // 기존 code 유지 또는 기본값 설정
+                      data: [...(addressList?.data || []), newAddress],
+                    }
+
+                    setAddressList(updatedAddressList) // 상태 갱신
+
+                    addAddress(
+                      id, // 고유 id
+                      selectedAddress.address_name, // 주소
+                      false, // isCurrentLocation 값
+                      { latitude, longitude }, // 좌표 정보
+                      priority // 우선순위 값
+                    )
                   }
                 }
-                setIsLoading(false)
               }
             )
-
-            console.log('현재 위치가 설정되었습니다!')
           } catch (error) {
             setErrorMessage('위치 설정에 실패했습니다.')
+          } finally {
             setIsLoading(false)
           }
         },
         (error) => {
           console.log(error.message)
-          setIsLoading(false)
           setErrorMessage('위치를 가져오는 데 실패했습니다. 권한을 확인하세요.')
+          setIsLoading(false)
         }
       )
     } else {
@@ -146,8 +287,10 @@ export const useAddress = () => {
     addresses,
     isLoading,
     errorMessage,
-    userLocation,
     handleSetCurrentLocation,
+    addNewLocation,
+    updatePriority,
+    deleteLocation,
     setAddress,
     address,
   }

--- a/src/pages/Main/Address.tsx
+++ b/src/pages/Main/Address.tsx
@@ -6,6 +6,7 @@ import arrow from '../../assets/common/Arrow.svg'
 import AddressCard from '../../components/Main/AddressCard'
 import { useAddress } from '../../hooks/Main/UseAddress'
 import LoadingSplash from '../Splash/LoadingSplash'
+import NoContents from '../../components/Community/NoContents'
 
 export default function Address() {
   const { addresses, isLoading, handleSetCurrentLocation } = useAddress()
@@ -58,19 +59,24 @@ export default function Address() {
             </button>
           </article>
           <article className="pt-[11px]">
-            {addresses.map((item, index) => (
-              <AddressCard
-                key={
-                  item.isCurrentLocation
-                    ? `${item.address}-${index}`
-                    : `${index}`
-                } // 각 주소마다 고유한 key 설정
-                index={index}
-                selected={item.selected}
-                address={item.address}
-                isLastAddress={index === addresses.length - 1}
-              />
-            ))}
+            {addresses.length > 0 ? (
+              addresses.map((item, index) => (
+                <AddressCard
+                  key={
+                    item.isCurrentLocation
+                      ? `${item.address}-${index}`
+                      : `${index}`
+                  } // 각 주소마다 고유한 key 설정
+                  id={item.id}
+                  index={index}
+                  selected={item.selected}
+                  address={item.address}
+                  isLastAddress={index === addresses.length - 1}
+                />
+              ))
+            ) : (
+              <NoContents subjectKey="address" />
+            )}
           </article>
         </section>
       </div>

--- a/src/pages/Main/Address.tsx
+++ b/src/pages/Main/Address.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import Cn from '../../utils/Cn'
 import search from '../../assets/common/Search.svg'
@@ -9,7 +10,12 @@ import LoadingSplash from '../Splash/LoadingSplash'
 import NoContents from '../../components/Community/NoContents'
 
 export default function Address() {
-  const { addresses, isLoading, handleSetCurrentLocation } = useAddress()
+  const { addresses, isLoading, handleSetCurrentLocation, fetchAddressList } =
+    useAddress()
+
+  useEffect(() => {
+    fetchAddressList()
+  }, [])
 
   return (
     <>

--- a/src/pages/Main/Address.tsx
+++ b/src/pages/Main/Address.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useState, useEffect, useRef, ChangeEvent } from 'react'
 import { Link } from 'react-router-dom'
 import Cn from '../../utils/Cn'
 import search from '../../assets/common/Search.svg'
@@ -9,12 +9,148 @@ import { useAddress } from '../../hooks/Main/UseAddress'
 import LoadingSplash from '../Splash/LoadingSplash'
 import NoContents from '../../components/Community/NoContents'
 
+// 장소 검색 결과 타입 정의
+interface Place {
+  id: string
+  place_name: string
+  address_name: string // 지번 주소
+  road_address_name: string // 도로명 주소
+  phone: string
+  x: string // 경도
+  y: string // 위도
+}
+
 export default function Address() {
-  const { addresses, isLoading, handleSetCurrentLocation, fetchAddressList } =
-    useAddress()
+  const {
+    addresses,
+    isLoading,
+    handleSetCurrentLocation,
+    fetchAddressList,
+    addNewLocation,
+  } = useAddress()
+
+  // 새로 추가된 상태들
+  const [searchTerm, setSearchTerm] = useState('')
+  const [searchResults, setSearchResults] = useState<Place[]>([])
+  const [showResults, setShowResults] = useState(false)
+  const resultsRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     fetchAddressList()
+  }, [])
+
+  // 카카오 장소 검색 함수 (복합 검색)
+  const searchPlaces = () => {
+    // 카카오 지도 API가 로드되지 않았을 경우 early return
+    if (!window.kakao || !window.kakao.maps || !window.kakao.maps.services) {
+      console.error('Kakao maps API not loaded')
+      return
+    }
+
+    const places = new window.kakao.maps.services.Places()
+
+    // 키워드 검색, 지번 주소, 도로명 주소 모두 검색 가능
+    places.keywordSearch(
+      searchTerm,
+      (result: Place[], status: string, pagination: any) => {
+        if (status === window.kakao.maps.services.Status.OK) {
+          // 도로명 주소와 지번 주소 모두 보여주기
+          const formattedResults = result.map((place) => ({
+            ...place,
+            display_address: place.road_address_name || place.address_name,
+          }))
+
+          setSearchResults(formattedResults)
+          setShowResults(true)
+        } else {
+          setSearchResults([])
+          setShowResults(false)
+        }
+      },
+      {
+        size: 5, // 최대 5개 결과만 가져오기
+        // 검색 옵션: 전체 영역에서 검색
+        location: new window.kakao.maps.LatLng(37.566826, 126.9786567), // 서울 중심 좌표
+      }
+    )
+  }
+
+  // 검색어 정제 함수 추가
+  const sanitizeSearchTerm = (term: string) => {
+    // 특수 문자 제거, 여러 공백 제거, 양쪽 공백 트림
+    return term
+      .replace(/[^\w\s가-힣]/g, '') // 특수 문자 제거 (알파벳, 숫자, 한글, 공백 제외)
+      .replace(/\s+/g, ' ') // 연속된 공백을 단일 공백으로 대체
+      .trim()
+  }
+
+  // 입력 변경 핸들러 수정
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const rawValue = e.target.value
+    const value = sanitizeSearchTerm(rawValue)
+    setSearchTerm(rawValue) // 원본 입력값 유지
+
+    // 최소 2글자 이상일 때만 검색
+    if (value.length >= 2) {
+      const places = new window.kakao.maps.services.Places()
+
+      places.keywordSearch(
+        value,
+        (result: Place[], status: string) => {
+          if (status === window.kakao.maps.services.Status.OK) {
+            setSearchResults(result)
+            setShowResults(true)
+          } else {
+            setSearchResults([])
+            setShowResults(false)
+          }
+        },
+        {
+          size: 5, // 최대 5개 결과만 가져오기
+          location: new window.kakao.maps.LatLng(37.566826, 126.9786567), // 서울 중심 좌표
+        }
+      )
+    } else {
+      setShowResults(false)
+    }
+  }
+
+  // 장소 클릭 핸들러
+  const handlePlaceClick = async (place: Place) => {
+    try {
+      // 선택된 장소의 좌표로 주소 추가
+      await addNewLocation(
+        parseFloat(place.y), // 위도
+        parseFloat(place.x) // 경도
+      )
+
+      // 입력창 초기화 및 결과 숨기기
+      setSearchTerm('')
+      setShowResults(false)
+    } catch (error) {
+      console.error('위치 추가 중 오류:', error)
+      alert('위치를 추가하는 중 오류가 발생했습니다.')
+    }
+  }
+
+  // 외부 클릭 시 결과 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        resultsRef.current &&
+        !resultsRef.current.contains(event.target as Node) &&
+        inputRef.current &&
+        !inputRef.current.contains(event.target as Node)
+      ) {
+        setShowResults(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
   }, [])
 
   return (
@@ -22,7 +158,7 @@ export default function Address() {
       {isLoading && <LoadingSplash />}
       <div className="flex flex-col items-center justify-center">
         <header>
-          <div className="pt-7 pl-[17px] pr-[19px] pb-[6px] w-[390px]">
+          <div className="pt-7 pl-[17px] pr-[19px] pb-[6px] w-[390px] relative">
             <div className="flex flex-row gap-[130px] items-center">
               <Link to={'/'}>
                 <img src={arrow} alt="arrow" className="rotate-90" />
@@ -33,8 +169,11 @@ export default function Address() {
             </div>
             <div className="relative mt-[15px] w-full">
               <input
+                ref={inputRef}
                 id="searchStore"
                 type="text"
+                value={searchTerm}
+                onChange={handleInputChange}
                 placeholder="지번, 도로명으로 검색해보세요"
                 className={Cn(
                   'py-[13px] pl-[13px] pr-[27px] w-full font-R00 focus:outline-none',
@@ -46,6 +185,31 @@ export default function Address() {
                 alt="trackIcon"
                 className="absolute top-1/2 right-4 transform -translate-y-1/2"
               />
+
+              {showResults && searchResults.length > 0 && (
+                <div
+                  ref={resultsRef}
+                  className="absolute mx-0 mt-2 w-full max-h-[200px] overflow-y-auto border border-200 bg-white z-20 shadow-lg rounded-lg"
+                >
+                  {searchResults.map((place) => (
+                    <div
+                      key={place.id}
+                      className="p-3 cursor-pointer hover:bg-gray-200 border-b border-b-200"
+                      onClick={() => handlePlaceClick(place)}
+                    >
+                      <div className="font-M00">{place.place_name}</div>
+                      <div className="font-SB00 text-sm text-gray-500">
+                        {place.road_address_name || place.address_name}
+                      </div>
+                      {place.phone && (
+                        <div className="font-SB00 text-xs text-gray-400">
+                          {place.phone}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
         </header>

--- a/src/pages/Main/Address.tsx
+++ b/src/pages/Main/Address.tsx
@@ -40,42 +40,6 @@ export default function Address() {
     fetchAddressList()
   }, [])
 
-  // 카카오 장소 검색 함수 (복합 검색)
-  const searchPlaces = () => {
-    // 카카오 지도 API가 로드되지 않았을 경우 early return
-    if (!window.kakao || !window.kakao.maps || !window.kakao.maps.services) {
-      console.error('Kakao maps API not loaded')
-      return
-    }
-
-    const places = new window.kakao.maps.services.Places()
-
-    // 키워드 검색, 지번 주소, 도로명 주소 모두 검색 가능
-    places.keywordSearch(
-      searchTerm,
-      (result: Place[], status: string, pagination: any) => {
-        if (status === window.kakao.maps.services.Status.OK) {
-          // 도로명 주소와 지번 주소 모두 보여주기
-          const formattedResults = result.map((place) => ({
-            ...place,
-            display_address: place.road_address_name || place.address_name,
-          }))
-
-          setSearchResults(formattedResults)
-          setShowResults(true)
-        } else {
-          setSearchResults([])
-          setShowResults(false)
-        }
-      },
-      {
-        size: 5, // 최대 5개 결과만 가져오기
-        // 검색 옵션: 전체 영역에서 검색
-        location: new window.kakao.maps.LatLng(37.566826, 126.9786567), // 서울 중심 좌표
-      }
-    )
-  }
-
   // 검색어 정제 함수 추가
   const sanitizeSearchTerm = (term: string) => {
     // 특수 문자 제거, 여러 공백 제거, 양쪽 공백 트림

--- a/src/store/useAddressStore.ts
+++ b/src/store/useAddressStore.ts
@@ -39,28 +39,16 @@ const useAddressStore = create<AddressStore>()(
       // 외부 데이터를 받아 상태 업데이트
       setAddresses: (addresses) => {
         set((state) => {
-          // 현재 선택된 주소 찾기
-          const currentSelectedAddress = state.addresses.find(
-            (addr) => addr.selected
-          )
+          // 이미 선택된 데이터가 있는지 확인
+          const currentSelected = state.addresses.find((addr) => addr.selected)
 
-          // 새로운 주소 목록에 선택된 주소 상태 적용
-          const updatedAddresses = addresses.map((newAddr) => {
-            // 만약 현재 선택된 주소와 ID가 같다면 selected 상태 유지
-            if (
-              currentSelectedAddress &&
-              currentSelectedAddress.id === newAddr.id
-            ) {
-              return {
-                ...newAddr,
-                selected: true,
-              }
-            }
-            return {
-              ...newAddr,
-              selected: false, // 다른 모든 주소는 선택 해제
-            }
-          })
+          // 새로운 데이터에 기존 선택 상태 적용
+          const updatedAddresses = addresses.map((addr, index) => ({
+            ...addr,
+            selected: currentSelected
+              ? currentSelected.id === addr.id
+              : index === 0, // 없으면 첫 번째 데이터 선택
+          }))
 
           return { addresses: updatedAddresses }
         })
@@ -86,24 +74,13 @@ const useAddressStore = create<AddressStore>()(
         priority = 0
       ) => {
         set((state) => {
-          // 좌표 중복 확인
-          const isDuplicate = state.addresses.some(
-            (addr) =>
-              addr.coordinates?.latitude === coordinates?.latitude &&
-              addr.coordinates?.longitude === coordinates?.longitude
-          )
-          if (isDuplicate) {
-            console.warn('이미 동일한 좌표의 주소가 존재합니다.')
-            return state
-          }
-
           return {
             addresses: [
               ...state.addresses,
               {
                 id,
                 address,
-                selected: false, // 새 주소는 기본적으로 선택되지 않음
+                selected: true,
                 isCurrentLocation,
                 coordinates,
                 priority,

--- a/src/store/useAddressStore.ts
+++ b/src/store/useAddressStore.ts
@@ -1,10 +1,13 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import Address from '../pages/Main/Address'
 
-interface Address {
+export interface Address {
+  id: number // 고유 식별자 추가
   address: string
   selected?: boolean
   isCurrentLocation?: boolean
+  priority?: number // 우선순위 필드 추가
   coordinates?: {
     latitude: number
     longitude: number
@@ -13,13 +16,19 @@ interface Address {
 
 interface AddressStore {
   addresses: Address[]
-  selectAddress: (index: number) => void
+  setAddresses: (addresses: Address[]) => void
+  selectAddress: (id: number) => void
   addAddress: (
+    id: number,
     address: string,
     isCurrentLocation?: boolean,
-    coordinates?: { latitude: number; longitude: number }
+    coordinates?: { latitude: number; longitude: number },
+    priority?: number
   ) => void
+  removeAddress: (id: number) => void
+  updatePriority: (id: number, priority: number) => void
   getSelectedAddress: () => string | undefined
+  checkDuplicateCoordinates: (latitude: number, longitude: number) => boolean
 }
 
 const useAddressStore = create<AddressStore>()(
@@ -27,44 +36,129 @@ const useAddressStore = create<AddressStore>()(
     (set, get) => ({
       addresses: [],
 
-      // 현재 설정된 주소
-      selectAddress: (index) => {
+      // 외부 데이터를 받아 상태 업데이트
+      setAddresses: (addresses) => {
         set((state) => {
-          const newAddresses = [...state.addresses]
-          newAddresses.forEach((item, idx) => {
-            item.selected = idx === index
+          // 현재 선택된 주소 찾기
+          const currentSelectedAddress = state.addresses.find(
+            (addr) => addr.selected
+          )
+
+          // 새로운 주소 목록에 선택된 주소 상태 적용
+          const updatedAddresses = addresses.map((newAddr) => {
+            // 만약 현재 선택된 주소와 ID가 같다면 selected 상태 유지
+            if (
+              currentSelectedAddress &&
+              currentSelectedAddress.id === newAddr.id
+            ) {
+              return {
+                ...newAddr,
+                selected: true,
+              }
+            }
+            return {
+              ...newAddr,
+              selected: false, // 다른 모든 주소는 선택 해제
+            }
           })
+
+          return { addresses: updatedAddresses }
+        })
+      },
+
+      // 특정 주소 선택
+      selectAddress: (id) => {
+        set((state) => {
+          const newAddresses = state.addresses.map((address) => ({
+            ...address,
+            selected: address.id === id,
+          }))
           return { addresses: newAddresses }
         })
       },
 
-      // 새로운 받아온 주소가 추가된 주소 리스트
-      addAddress: (address: string, isCurrentLocation = false, coordinates) => {
+      // 새로운 주소 추가
+      addAddress: (
+        id,
+        address,
+        isCurrentLocation = false,
+        coordinates,
+        priority = 0
+      ) => {
+        set((state) => {
+          // 좌표 중복 확인
+          const isDuplicate = state.addresses.some(
+            (addr) =>
+              addr.coordinates?.latitude === coordinates?.latitude &&
+              addr.coordinates?.longitude === coordinates?.longitude
+          )
+          if (isDuplicate) {
+            console.warn('이미 동일한 좌표의 주소가 존재합니다.')
+            return state
+          }
+
+          return {
+            addresses: [
+              ...state.addresses,
+              {
+                id,
+                address,
+                selected: false, // 새 주소는 기본적으로 선택되지 않음
+                isCurrentLocation,
+                coordinates,
+                priority,
+              },
+            ],
+          }
+        })
+      },
+
+      // 특정 주소 삭제
+      removeAddress: (id) => {
         set((state) => ({
-          addresses: [
-            ...state.addresses,
-            {
-              address,
-              selected: false,
-              isCurrentLocation,
-              coordinates, // 좌표 정보 저장
-            },
-          ],
+          addresses: state.addresses.filter((address) => address.id !== id),
         }))
       },
 
-      // 현재 설정된 주소 반환
+      // 우선순위 업데이트
+      updatePriority: (id, priority) => {
+        set((state) => ({
+          addresses: state.addresses.map((address) =>
+            address.id === id
+              ? { ...address, priority } // 우선순위 업데이트
+              : address
+          ),
+        }))
+      },
+
+      // 선택된 주소 반환
       getSelectedAddress: () => {
         const state = get()
-        const selectedAddress = state.addresses.find(
-          (address) => address.selected
-        )
+        const addresses = Array.isArray(state.addresses) ? state.addresses : [] // 방어적 체크
+        const selectedAddress = addresses.find((address) => address.selected)
         return selectedAddress ? selectedAddress.address : undefined
+      },
+
+      // 좌표 중복 여부 확인
+      checkDuplicateCoordinates: (latitude, longitude) => {
+        return get().addresses.some(
+          (addr) =>
+            addr.coordinates?.latitude === latitude &&
+            addr.coordinates?.longitude === longitude
+        )
       },
     }),
     {
       name: 'selectedAddress', // 로컬스토리지 키 이름
-      partialize: (state) => ({ addresses: state.addresses }), // 저장할 상태만 선택
+      partialize: (state) => {
+        // 선택된 주소만 저장
+        const selectedAddress = state.addresses.find(
+          (address) => address.selected
+        )
+        return selectedAddress
+          ? { addresses: [selectedAddress] }
+          : { addresses: [] }
+      },
     }
   )
 )

--- a/src/types/Main/AddressResponse.ts
+++ b/src/types/Main/AddressResponse.ts
@@ -1,4 +1,12 @@
 export interface addressResponse {
+  id: number
   latitude: number
   longitude: number
+  priority: number
+  roadAddressName?: string
+}
+
+export interface addressListResponse {
+  code: number
+  data: addressResponse[]
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

>

## 📝작업 내용

> 변경된 주소 설정 api를 연동하였습니다.
> 주소 검색 기능을 추가하였습니다.
> 중복되는 주소의 경우 등록되지 않습니다.
> 재로그인시에는 사용자가 마지막으로 설정했던 주소가 헤더에 보입니다.
> 주소 텍스트 클릭시에도 주소 설정 페이지로 이동할 수 있도록 해두었습니다.

### 스크린샷 

> ![무제](https://github.com/user-attachments/assets/623844ca-e0f7-4bf2-9bfb-10a20db678f9)

## 💬리뷰 요구사항

> 로컬에서는 바로 실행해 보실 수 있으나, 배포된 사이트에서 이용하시는 경우에는 Vercel 환경변수 `VITE_APP_KAKAO_LOGIN_RETURN_URL`을 이용하시려는 사이트로 바꿔주셔야 합니당
> 현재는 제가 잘 되나 확인해 보려고 제 브랜치로 해두었는데 머지되면 main 브랜치 사이트로 바꿔두겠습니당
