### PR TITLE
[FIX] 선한영향력 필터 버튼 정렬, api 경로 바르게 수정

### DIFF
--- a/src/components/Around/KakaoList.tsx
+++ b/src/components/Around/KakaoList.tsx
@@ -46,7 +46,15 @@ const KakaoList: React.FC<KakaoListProps> = ({ setIsLoading }) => {
 
   useEffect(() => {
     if (selectedFilterOption) {
-      const filter = Filter.find((f) => f.label === selectedFilterOption)
+      let filter
+      if (selectedFilterOption === `선한영향력\n가게`) {
+        filter = Filter.find(
+          (f) => normalizeText(f.label) === normalizeText(selectedFilterOption)
+        )
+      } else {
+        filter = Filter.find((f) => f.label === selectedFilterOption)
+      }
+      console.log('bug:', filter)
       if (filter) {
         setSelectedCategoryId(filter.category_id || 3)
       }
@@ -149,7 +157,16 @@ const KakaoList: React.FC<KakaoListProps> = ({ setIsLoading }) => {
   // 페이지 로드 시 선택된 필터 버튼이 가운데로 오도록 처리
   useEffect(() => {
     if (selectedFilterOption && filterContainerRef.current) {
-      const selectedButton = document.getElementById(selectedFilterOption)
+      let selectedButton
+      if (selectedFilterOption === `선한영향력\n가게`) {
+        selectedButton = document.getElementById(
+          normalizeText(selectedFilterOption)
+        )
+      } else {
+        selectedButton = document.getElementById(selectedFilterOption)
+      }
+      console.log('selectedFilterOption:', selectedFilterOption)
+      console.log('selectedButton: ', selectedButton)
       if (selectedButton) {
         selectedButton.scrollIntoView({
           behavior: 'smooth',
@@ -159,6 +176,13 @@ const KakaoList: React.FC<KakaoListProps> = ({ setIsLoading }) => {
       }
     }
   }, [selectedFilterOption]) // selectedFilterOption이 변경될 때마다 실행
+
+  const normalizeText = (text: string) => {
+    return text
+      .replace(/\s+/g, '') // 공백 제거
+      .replace(/[^a-zA-Z가-힣0-9]/g, '') // 특수 문자 제거
+      .concat('😇')
+  }
 
   // 24/11/20 희진 변경
   const handleFilterClick = (
@@ -200,11 +224,14 @@ const KakaoList: React.FC<KakaoListProps> = ({ setIsLoading }) => {
           {Filter.map((filter) => (
             <FilterButton
               key={filter.id}
-              id={filter.id}
+              id={filter.id} // 정규화된 id
               label={filter.label}
-              category_id={filter.category_id ? filter.category_id : 0}
+              category_id={filter.category_id || 0}
               selectedFilter={selectedFilter}
-              selected={selectedFilterOption === filter.label}
+              selected={
+                normalizeText(selectedFilterOption) ===
+                normalizeText(filter.label)
+              }
               onClick={() =>
                 handleFilterClick(filter.id, filter.label, filter.category_id)
               }

--- a/src/components/Around/KakaoMap.tsx
+++ b/src/components/Around/KakaoMap.tsx
@@ -55,6 +55,23 @@ const KaKaoMap = () => {
   }
 
   useEffect(() => {
+    if (selectedFilterOption) {
+      let filter
+      if (selectedFilterOption === `선한영향력\n가게`) {
+        filter = Filter.find(
+          (f) => normalizeText(f.label) === normalizeText(selectedFilterOption)
+        )
+      } else {
+        filter = Filter.find((f) => f.label === selectedFilterOption)
+      }
+      console.log('bug:', filter)
+      if (filter) {
+        setSelectedCategoryId(filter.category_id || 3)
+      }
+    }
+  }, [selectedFilterOption])
+
+  useEffect(() => {
     const selectedAddress = getSelectedAddress()
     if (selectedAddress) {
       const geocoder = new kakao.maps.services.Geocoder()
@@ -90,7 +107,7 @@ const KaKaoMap = () => {
         const url =
           selectedCategoryId === 3
             ? `/stores?latitude=${userPosition.lat}&longitude=${userPosition.lng}`
-            : selectedCategoryId === 11
+            : selectedCategoryId === 12
             ? `/stores?options=score>=4&latitude=${userPosition.lat}&longitude=${userPosition.lng}` // 검증된 맛집 카테고리
             : `/stores/category/${selectedCategoryId}?latitude=${userPosition.lat}&longitude=${userPosition.lng}` // 나머지 카테고리
 
@@ -114,13 +131,28 @@ const KaKaoMap = () => {
     return () => {
       ignore = true
     }
-  }, [userPosition, selectedCategoryId, selectedFilter, setPlaces])
+  }, [
+    userPosition,
+    selectedCategoryId,
+    selectedFilter,
+    setPlaces,
+    selectedFilterOption,
+  ])
 
   // 24/11/20 희진 추가
   // 페이지 로드 시 선택된 필터 버튼이 가운데로 오도록 처리
   useEffect(() => {
     if (selectedFilterOption && filterContainerRef.current) {
-      const selectedButton = document.getElementById(selectedFilterOption)
+      let selectedButton
+      if (selectedFilterOption === `선한영향력\n가게`) {
+        selectedButton = document.getElementById(
+          normalizeText(selectedFilterOption)
+        )
+      } else {
+        selectedButton = document.getElementById(selectedFilterOption)
+      }
+      console.log('selectedFilterOption:', selectedFilterOption)
+      console.log('selectedButton: ', selectedButton)
       if (selectedButton) {
         selectedButton.scrollIntoView({
           behavior: 'smooth',
@@ -130,6 +162,13 @@ const KaKaoMap = () => {
       }
     }
   }, [selectedFilterOption]) // selectedFilterOption이 변경될 때마다 실행
+
+  const normalizeText = (text: string) => {
+    return text
+      .replace(/\s+/g, '') // 공백 제거
+      .replace(/[^a-zA-Z가-힣0-9]/g, '') // 특수 문자 제거
+      .concat('😇')
+  }
 
   useEffect(() => {
     if (selectedPlace && mapRef.current) {
@@ -235,7 +274,10 @@ const KaKaoMap = () => {
                 label={filter.label}
                 category_id={filter.category_id ? filter.category_id : 0} // 24/11/22 희진 추가
                 selectedFilter={selectedFilter}
-                selected={selectedFilterOption === filter.label} // 24/11/20 희진 추가
+                selected={
+                  normalizeText(selectedFilterOption) ===
+                  normalizeText(filter.label)
+                } // 24/11/20 희진 추가
                 onClick={() =>
                   handleFilterClick(filter.id, filter.label, filter.category_id)
                 } // 24/11/20 희진 추가


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> - 메인 화면에서 "선한 영향력" 카테고리 클릭시 해당 필터가 클릭된 상태로 보여지게 하였습니다.
> - 지도 리스트와 맵 뷰의 선한 영향력 가게 조회 결과가 다르더라구요! 이 부분도 바르게 수정해 두었습니다.

### 스크린샷 
> ![무제](https://github.com/user-attachments/assets/ece6b808-c211-4209-8580-3c0807d23763)

## 💬리뷰 요구사항
